### PR TITLE
Fix colorbar removal in viewer

### DIFF
--- a/testFiles/visualization/interface.py
+++ b/testFiles/visualization/interface.py
@@ -206,8 +206,9 @@ class EventViewer(QMainWindow):
         self._face_ax.clear()
         self._geom.draw_face(self._face_ax, show_grid=False)
         im2 = self._face_ax.imshow(np.ma.masked_equal(fm, 0.0), cmap="viridis", origin="upper", alpha=0.8)
-        if hasattr(self, "_cbar"):
-            self._cbar.remove()
+        cbar = getattr(self, "_cbar", None)
+        if cbar is not None and cbar.ax is not None:
+            cbar.remove()
         self._cbar = self._face_canvas.figure.colorbar(im2, ax=self._face_ax, pad=0.02)
 
         for t in self._text_artists:


### PR DESCRIPTION
## Summary
- fix crash when switching events by avoiding removing a colorbar twice

## Testing
- `python -m py_compile \
  `git ls-files '*.py'`

------
https://chatgpt.com/codex/tasks/task_e_68486316b0c0832f964fc07855f7894b