### PR TITLE
Update event display to ROOT-based layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,12 @@ energy deposits stored in ROOT files on top of the detector face layout.
    ```
 3. Display a specific event from a ROOT file:
    ```bash
-   python -m testFiles.visualization.event_display mydata.root BRANCH_NAME --event 0
+   python -m testFiles.visualization.event_display mydata.root 0
    ```
 4. Launch the interactive viewer to browse events:
    ```bash
-   python -m testFiles.visualization.interface mydata.root BRANCH_NAME
+   python -m testFiles.visualization.interface mydata.root
    ```
 
-Replace `BRANCH_NAME` with the name of the branch containing the per-channel
+Replace `EVENT_NUMBER` with the desired event identifier. The interactive viewer
 energies or charges.

--- a/testFiles/visualization/event_display.py
+++ b/testFiles/visualization/event_display.py
@@ -1,83 +1,113 @@
 #!/usr/bin/env python3
-"""Simple event display using the Geometry class.
+"""ROOT-based event display for the calorimeter.
 
-This script reads hit or energy information from a ROOT file and
-visualizes it on top of the calorimeter face layout using matplotlib.
+This script opens a ROOT file containing an ``EventTree`` and draws the
+energy recorded in all FERS boards using a fixed 20×12 layout.
 
-Example usage:
-    python event_display.py myfile.root FERS_Board1_energyHG
+Usage:
+    python -m testFiles.visualization.event_display /path/to/file.root EVENT_N
 """
 
 from __future__ import annotations
 
-import argparse
+import sys
+import json
 from pathlib import Path
 
-import matplotlib.pyplot as plt
-import numpy as np
-import uproot
+import ROOT
 
-from .geometry import Geometry
+# Mapping helpers
+from ..utils.channel_map import build_map_FERS1_ixy
 
-
-def display_event(root_file: Path, branch: str, event: int = 0):
-    """Display a single event from *root_file* using data from *branch*.
-
-    Parameters
-    ----------
-    root_file : Path
-        Path to the ROOT file containing an ``EventTree``.
-    branch : str
-        Name of the branch containing per-channel energies or charges.
-        The branch is expected to be an array with length equal to the
-        number of channels defined in :class:`Geometry`.
-    event : int, optional
-        Index of the event to display (default is 0).
-    """
-    geom = Geometry()
-
-    with uproot.open(root_file) as file:
-        tree = file["EventTree"]
-        values = tree[branch].array(library="np")
-        if event >= len(values):
-            raise IndexError(f"Event {event} out of range (max {len(values) - 1})")
-        energies = values[event]
-
-    xs = []
-    ys = []
-    vals = []
-    for ch, val in enumerate(energies):
-        if ch in geom.channel_map:
-            x, y = geom.get_xy(ch)
-            xs.append(x)
-            ys.append(y)
-            vals.append(val)
-
-    fig, ax = plt.subplots(figsize=(8, 6))
-    geom.draw_face(ax)
-    sc = ax.scatter(xs, ys, c=vals, cmap="viridis", s=80, marker="s")
-    cmap = sc.get_cmap()
-    vmin, vmax = sc.get_clim()
-    texts = []
-    for x, y, v in zip(xs, ys, vals):
-        rgba = cmap((v - vmin) / (vmax - vmin + 1e-8))
-        lum = 0.2126 * rgba[0] + 0.7152 * rgba[1] + 0.0722 * rgba[2]
-        txt_color = "white" if lum < 0.5 else "black"
-        texts.append(ax.text(x, y, f"{int(v)}", ha="center", va="center",
-                             fontsize=6, color=txt_color))
-    ax.set_title(f"Event {event} : {branch}")
-    plt.colorbar(sc, ax=ax, label="Energy")
-    plt.show()
+# Ensure the local CMSPLOTS package takes precedence
+exp_pkg = Path(__file__).resolve().parents[1] / "CMSPLOTS"
+sys.path.insert(0, str(exp_pkg))
+from CMSPLOTS.myFunction import DrawHistos
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Calorimeter event display")
-    parser.add_argument("rootfile", type=Path, help="Input ROOT file")
-    parser.add_argument("branch", help="Branch with per-channel data")
-    parser.add_argument("--event", type=int, default=0, help="Event index")
-    args = parser.parse_args()
+def build_horizontal_map() -> dict[str, dict[int, tuple[int, int]]]:
+    """Return per-board channel → (iX,iY) maps for a 20×12 layout."""
+    base = build_map_FERS1_ixy()
+    maps: dict[str, dict[int, tuple[int, int]]] = {}
+    board_order = [4, 3, 2, 1, 0]
+    for idx, board in enumerate(board_order):
+        shift_x = (4 * (idx + 1)) % 20
+        shift_y = -4 if board == 3 else 0
+        maps[f"Board{board}"] = {
+            ch: ((ix + shift_x) % 20, iy + shift_y) for ch, (ix, iy) in base.items()
+        }
+    return maps
 
-    display_event(args.rootfile, args.branch, args.event)
+
+def display_event(root_file: Path, event_number: int) -> None:
+    """Display ``event_number`` from ``root_file`` using the board layout."""
+    noise_path = Path(__file__).resolve().parents[1] / "results" / "fers_noises.json"
+    with open(noise_path, "r") as f:
+        _noises = json.load(f)  # currently unused but kept for completeness
+
+    infile = ROOT.TFile(str(root_file), "READ")
+    if infile.IsZombie():
+        raise RuntimeError(f"Failed to open {root_file}")
+    tree = infile.Get("EventTree")
+    if not tree:
+        raise RuntimeError("EventTree not found in file")
+
+    evt = int(event_number)
+    entry_id = None
+    for i in range(tree.GetEntries()):
+        tree.GetEntry(i)
+        if getattr(tree, "event_n", -1) == evt:
+            entry_id = i
+            break
+    if entry_id is None:
+        raise RuntimeError(f"Event {evt} not found")
+    tree.GetEntry(entry_id)
+
+    maps = build_horizontal_map()
+    hist = ROOT.TH2F(
+        "event",
+        f"Event {evt};iX;iY",
+        20,
+        -0.5,
+        19.5,
+        12,
+        -4.5,
+        7.5,
+    )
+
+    for board in [4, 3, 2, 1, 0]:
+        arr = getattr(tree, f"FERS_Board{board}_energyHG")
+        for ch, raw in enumerate(arr):
+            ix, iy = maps[f"Board{board}"][ch]
+            hist.Fill(ix, iy, int(raw))
+
+    zmax = hist.GetMaximum()
+    DrawHistos(
+        [hist],
+        "",
+        -0.5,
+        19.5,
+        "iX",
+        -4.5,
+        7.5,
+        "iY",
+        f"event_display_{evt}",
+        dology=False,
+        drawoptions=["COLZ0 TEXT0"],
+        doth2=True,
+        zmin=0,
+        zmax=zmax,
+        W_ref=1400,
+        noLumi=True,
+        noCMS=True,
+    )
+
+
+def main() -> None:
+    if len(sys.argv) != 3:
+        print("Usage: python -m testFiles.visualization.event_display FILE.root EVENT")
+        sys.exit(1)
+    display_event(Path(sys.argv[1]), int(sys.argv[2]))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- rewrite `event_display.py` to use ROOT TH2 and new board mapping
- adjust README usage examples for updated script

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684882785a80832fba7efcb7b3edd9fe